### PR TITLE
Add countdown interactions

### DIFF
--- a/cogs/about.py
+++ b/cogs/about.py
@@ -30,7 +30,7 @@ class About(commands.Cog):
 
     return embed;
 
-  # Registering slash command
+  # Register slash command
   @slash_command(guild_ids=config["guildIDs"], description="Displays information about Mirai")
   async def about(self, ctx):
     embed = self.generate_about_embed(ctx);

--- a/cogs/countdown.py
+++ b/cogs/countdown.py
@@ -44,14 +44,26 @@ class Countdown(commands.Cog):
     view.add_item(cancel_button);
     view.add_item(confirm_button);
 
+    confirm_button.callback = self.handle_on_confirm;
     cancel_button.callback = self.handle_on_cancel;
-
-    return view;
     
+    return view;
+      
   async def handle_on_cancel(self, interaction):
     embed = discord.Embed();
     embed.color = discord.Colour(16711680);
     embed.description = "Cancelled Countdown";
+
+    return await interaction.response.edit_message(embed=embed, view=None);
+
+  async def handle_on_confirm(self, interaction):
+    current_guild = await self.bot.fetch_guild(interaction.guild_id);
+    countdown_category = await current_guild.create_category('Countdown');
+    countdown_channel = await countdown_category.create_text_channel(f'{interaction.user.name}-day-{self.days}');
+
+    embed = discord.Embed();
+    embed.color = discord.Colour(3066993);
+    embed.description = f"Countdown successfully set in {countdown_channel.mention}!";
 
     return await interaction.response.edit_message(embed=embed, view=None);
 
@@ -62,6 +74,7 @@ class Countdown(commands.Cog):
       embed = self.generate_countdown_information_embed();
       return await ctx.respond(embed=embed);
 
+    self.days = days;
     actions_view = self.generate_buttons();
     embed = self.generate_countdown_confirmation_embed(days);
 

--- a/cogs/countdown.py
+++ b/cogs/countdown.py
@@ -48,7 +48,9 @@ class Countdown(commands.Cog):
     cancel_button.callback = self.handle_on_cancel;
     
     return view;
-      
+
+  # Handler when a user clicks the Cancel Button
+  # Edits the original message with a new embed and clears buttons
   async def handle_on_cancel(self, interaction):
     embed = discord.Embed();
     embed.color = discord.Colour(16711680);
@@ -56,19 +58,29 @@ class Countdown(commands.Cog):
 
     return await interaction.response.edit_message(embed=embed, view=None);
 
+  # Handler when a user clicks the Let's go Button
+  # 3 parts:
+  # - Creates a new channel under a new category
+  # - Edits the original interaction message with a success message with a link to the newly created channel
+  # - Finally pings the user on the newly created channel the start of the countdown
+  # I initially wanted to move the user to the text channel but seems discord doesn't support that; only voice channel movement. 
+  # I guess it's hard to keep track and merits probably doesn't outweight the implementation
   async def handle_on_confirm(self, interaction):
+    # Creates a new channel under a new category
     current_guild = await self.bot.fetch_guild(interaction.guild_id);
-    countdown_category = await current_guild.create_category('Countdown');
+    countdown_category = await current_guild.create_category('Mirai Countdown');
     countdown_channel = await countdown_category.create_text_channel(f'{interaction.user.name}-day-{self.days}');
 
+    # Edits original interaction message with link to new channel
     embed = discord.Embed();
     embed.color = discord.Colour(3066993);
     embed.description = f"Countdown successfully set in {countdown_channel.mention}!";
     await interaction.response.edit_message(embed=embed, view=None);
 
-    return await countdown_channel.send(f'{interaction.user.mention} Day {self.days}! Good luck :D');
+    # Pings user in created channel
+    return await countdown_channel.send(f'{interaction.user.mention} Day {self.days}! Good luck :D'); 
 
-  # Registering slash command
+  # Register slash command
   @slash_command(guild_ids=config["guildIDs"], description="Starts a countdown from a set number of days")
   async def countdown(self, ctx, days: Option(int, "Enter number of days!", required=False)):
     if not days:

--- a/cogs/countdown.py
+++ b/cogs/countdown.py
@@ -44,8 +44,17 @@ class Countdown(commands.Cog):
     view.add_item(cancel_button);
     view.add_item(confirm_button);
 
+    cancel_button.callback = self.handle_on_cancel;
+
     return view;
     
+  async def handle_on_cancel(self, interaction):
+    embed = discord.Embed();
+    embed.color = discord.Colour(16711680);
+    embed.description = "Cancelled Countdown";
+
+    return await interaction.response.edit_message(embed=embed, view=None);
+
   # Registering slash command
   @slash_command(guild_ids=config["guildIDs"], description="Starts a countdown from a set number of days")
   async def countdown(self, ctx, days: Option(int, "Enter number of days!", required=False)):

--- a/cogs/countdown.py
+++ b/cogs/countdown.py
@@ -64,8 +64,9 @@ class Countdown(commands.Cog):
     embed = discord.Embed();
     embed.color = discord.Colour(3066993);
     embed.description = f"Countdown successfully set in {countdown_channel.mention}!";
+    await interaction.response.edit_message(embed=embed, view=None);
 
-    return await interaction.response.edit_message(embed=embed, view=None);
+    return await countdown_channel.send(f'{interaction.user.mention} Day {self.days}! Good luck :D');
 
   # Registering slash command
   @slash_command(guild_ids=config["guildIDs"], description="Starts a countdown from a set number of days")


### PR DESCRIPTION
#### Context
Add countdown interactions for each scenario. Moving the user to the created channel was part of the design but after investigation it looks like discord doesn't support that feature. They only allow users to be moved to a voice channel. Probably because implementing such a feature is complicated to keep track of

A bummer but oh well not the end of the world, I made an alternative with editing the original interaction with the link of the new channel so they can just click it instead

![image](https://user-images.githubusercontent.com/42207245/148987384-8af34c60-c75e-4ba8-95a8-8776de0a21f0.png)
![image](https://user-images.githubusercontent.com/42207245/148987449-ba001db1-54c4-4e0c-b61f-5883981ae154.png)
![image](https://user-images.githubusercontent.com/42207245/148987476-b4e96fec-f57f-4116-a82c-2a5d2a9c77fa.png)

#### Change
- Wire up on cancel handler
- Wire up on confirm handler
- Ping user in countdown channel

#### Release Notes
Add countdown interactions