### PR TITLE
Post and mid countdown interactions

### DIFF
--- a/cogs/countdown.py
+++ b/cogs/countdown.py
@@ -1,6 +1,6 @@
 import discord;
 import json;
-import asyncio;
+
 from discord.commands import slash_command, Option;
 from discord.ext import commands;
 from discord.ui import Button, View;

--- a/database/countdown_db.py
+++ b/database/countdown_db.py
@@ -80,7 +80,7 @@ class CountdownDatabase():
     delete_countdown = f"""
       DELETE FROM Countdown WHERE uuid=:uuid
     """
-
+    # TODO: Figure out how to properly cancel existing asyncio sleep tasks when stopping countdown
     cursor.execute(delete_countdown, {"uuid": uuid});
     return mirai_database.commit();
     

--- a/mirai.py
+++ b/mirai.py
@@ -13,6 +13,8 @@ with open("config/mirai.json") as file:
 async def on_ready():
   dev_channel = mirai.get_channel(929427727033982986);
   await dev_channel.send("I'm booting up! (◕ᴗ◕✿)");
+  # TODO: Start existing countdowns
+  # TODO: Delete countdowns that already have ended
 
 # Loads cogs into mirai
 # TODO: Make it a loop of the whole cogs folder

--- a/timer/timer.py
+++ b/timer/timer.py
@@ -63,7 +63,7 @@ class Timer():
       # Send end of countdown message
       embed = self.generate_end_countdown_embed();
       view = self.generate_button();
-      # await self.channel.edit(name=f"{self.user.name}-end"); # channel edit rate limit is 2 per 10 minutes
+      await self.channel.edit(name=f"{self.user.name}-end"); # channel edit rate limit is 2 per 10 minutes
       await self.channel.send(f'{self.user.mention}', embed=embed, view=view);
     
   # Updates timer pointers for next day
@@ -90,7 +90,7 @@ class Timer():
   async def start_day_timer(self, user, channel, difference, current):  
     async def start_countdown():
       countdown_content = f"{user.mention} Day {current}! Good luck :D" if current == self.days else f"{user.mention} Day {current}"
-      # current != self.days and await self.channel.edit(name=f"{self.user.name}-day-{current}"); # channel edit rate limit is 2 per 10 minutes
+      current != self.days and await self.channel.edit(name=f"{self.user.name}-day-{current}"); # channel edit rate limit is 2 per 10 minutes
       countdown_message = await channel.send(countdown_content);
 
       CountdownDatabase().update_countdown_message(countdown_message.id, self.countdown_uuid);
@@ -107,16 +107,18 @@ class Timer():
     
     return embed;
 
+  # Generates close button for end countdown message
   def generate_button(self):
     close_button = Button(label="Close", style=discord.ButtonStyle.secondary);
-
     view = View();
     view.add_item(close_button);
-
     close_button.callback = self.handle_on_close;
-
+    
     return view;
 
+  # Interaction handler when user clicks on close button
+  # Deletes countdown instance from our database
+  # Then deletes the countdown category and channel
   async def handle_on_close(self, interaction):
     CountdownDatabase().delete_countdown(self.countdown_uuid);
     await interaction.channel.category.delete();


### PR DESCRIPTION
#### Context
Add interactions for post and mid countdown experience to better close the loop. Getting a bit worried that the codebase is getting convoluted, there's a lot going on in the timer and countdown classes. Probably should revisit in the future to refactor. Only thing left is to restart and delete countdowns when bot initially starts up
Interactions:
1. Delete existing countdown message after day timer ends; user will only see one message per ping in the channel
2. Edit channel name to current day on every day timer
3. Delete countdown instance on ending message close

![image](https://user-images.githubusercontent.com/42207245/149654951-ebc918e4-20d2-45b3-adfb-ad6b27ecced3.png)
![image](https://user-images.githubusercontent.com/42207245/149654984-d92ea24d-9619-4af4-b57c-abb26f3d22f7.png)
![image](https://user-images.githubusercontent.com/42207245/149655016-ca13ca5c-7e64-4439-bd4a-eada6dbee788.png)
![image](https://user-images.githubusercontent.com/42207245/149655024-465f5172-a64b-4ac5-a88b-e3b37ab93e25.png)


#### Change
- Delete existing countdown message after day timer ends
- Edit channel to current day on every timer
- Delete countdown instance and channels after end

#### Release Notes
Add post and mid countdown interactions