### PR TITLE
Countdown interactions on startup

### DIFF
--- a/cogs/countdown.py
+++ b/cogs/countdown.py
@@ -105,7 +105,7 @@ class Countdown(commands.Cog):
     countdown_channel = self.bot.get_channel(countdown["channel_id"]);
     user = await self.bot.fetch_user(countdown["user_id"]);
 
-    return await Timer(countdown_channel, user, countdown, type="minute").start();
+    return await Timer(countdown_channel, user, countdown).start();
 
   # Register slash command and main handler for initialisation
   @slash_command(guild_ids=config["guildIDs"], description="Starts a countdown from a set number of days")

--- a/database/countdown_db.py
+++ b/database/countdown_db.py
@@ -72,6 +72,17 @@ class CountdownDatabase():
     countdown = cursor.fetchone();
     return countdown;
     
+  def get_all_countdowns(self):
+    mirai_database = self.connect_database();
+    mirai_database.row_factory = self.dict_factory;
+    cursor = mirai_database.cursor();
+    get_all_countdowns = f"""
+      SELECT * FROM COUNTDOWN
+    """
+    cursor.execute(get_all_countdowns);
+    countdowns = cursor.fetchall();
+    return countdowns;
+
   # Deletes a countdown from our database  
   # uuid: unique identifier of countdown
   def delete_countdown(self, uuid):

--- a/mirai.py
+++ b/mirai.py
@@ -1,5 +1,10 @@
 import discord;
-import json;
+import json
+import datetime;
+
+from database.countdown_db import CountdownDatabase
+from helpers import Helpers
+from timer.timer import Timer;
 
 mirai = discord.Bot();
 
@@ -13,6 +18,20 @@ with open("config/mirai.json") as file:
 async def on_ready():
   dev_channel = mirai.get_channel(929427727033982986);
   await dev_channel.send("I'm booting up! (◕ᴗ◕✿)");
+  countdowns = CountdownDatabase().get_all_countdowns();
+  for countdown in countdowns:
+    countdown_channel = mirai.get_channel(countdown["channel_id"]);
+    if datetime.datetime.now() < Helpers().format_to_datetime(countdown["ends_at"]):
+      countdown_message = countdown_channel.get_partial_message(countdown["message_id"]);
+      user = await mirai.fetch_user(countdown["user_id"]);
+      await countdown_message.delete();
+      await Timer(countdown_channel, user, countdown, type="minute").start();
+    else:
+      await countdown_channel.category.delete();
+      await countdown_channel.delete();
+      CountdownDatabase().delete_countdown(uuid=countdown["uuid"]);
+      
+
   # TODO: Start existing countdowns
   # TODO: Delete countdowns that already have ended
 

--- a/mirai.py
+++ b/mirai.py
@@ -21,6 +21,11 @@ async def on_ready():
   await dev_channel.send("I'm booting up! (◕ᴗ◕✿)");
   await run_existing_countdowns();
 
+# Function to execute existing countdowns
+# For each countdown, we want to check if the countdown has already ended or it's still ongoing
+# If ended, we delete it from our database along with the channels associated to it
+# If not, we create an asyncio task for each countdown
+# Finally we iterate though the asyncio tasks, calling them asynchronously but concurrently
 async def run_existing_countdowns():
   countdowns = CountdownDatabase().get_all_countdowns();
   countdown_tasks = [];

--- a/mirai.py
+++ b/mirai.py
@@ -35,7 +35,7 @@ async def run_existing_countdowns():
       countdown_message = countdown_channel.get_partial_message(countdown["message_id"]);
       user = await mirai.fetch_user(countdown["user_id"]);
       countdown_message and await countdown_message.delete();
-      countdown_tasks.append(asyncio.create_task(Timer(countdown_channel, user, countdown, type="minute").start()));
+      countdown_tasks.append(asyncio.create_task(Timer(countdown_channel, user, countdown).start()));
     else:
       await countdown_channel.category.delete();
       await countdown_channel.delete();

--- a/timer/timer.py
+++ b/timer/timer.py
@@ -63,7 +63,7 @@ class Timer():
       # Send end of countdown message
       embed = self.generate_end_countdown_embed();
       view = self.generate_button();
-      await self.channel.edit(name=f"{self.user.name}-end"); # channel edit rate limit is 2 per 10 minutes
+      # await self.channel.edit(name=f"{self.user.name}-end"); # channel edit rate limit is 2 per 10 minutes
       await self.channel.send(f'{self.user.mention}', embed=embed, view=view);
     
   # Updates timer pointers for next day
@@ -90,7 +90,7 @@ class Timer():
   async def start_day_timer(self, user, channel, difference, current):  
     async def start_countdown():
       countdown_content = f"{user.mention} Day {current}! Good luck :D" if current == self.days else f"{user.mention} Day {current}"
-      current != self.days and await self.channel.edit(name=f"{self.user.name}-day-{current}"); # channel edit rate limit is 2 per 10 minutes
+      # current != self.days and await self.channel.edit(name=f"{self.user.name}-day-{current}"); # channel edit rate limit is 2 per 10 minutes
       countdown_message = await channel.send(countdown_content);
 
       CountdownDatabase().update_countdown_message(countdown_message.id, self.countdown_uuid);

--- a/timer/timer.py
+++ b/timer/timer.py
@@ -72,7 +72,7 @@ class Timer():
       # Send end of countdown message
       embed = self.generate_end_countdown_embed();
       view = self.generate_button();
-      # await self.channel.edit(name=f"{self.user.name}-end"); # channel edit rate limit is 2 per 10 minutes
+      await self.channel.edit(name=f"{self.user.name}-end"); # channel edit rate limit is 2 per 10 minutes
       end_message = await self.channel.send(f'{self.user.mention}', embed=embed, view=view);
       return CountdownDatabase().update_countdown_message(end_message.id, self.countdown_uuid);
     
@@ -100,7 +100,7 @@ class Timer():
   async def start_day_timer(self, user, channel, difference, current):  
     async def start_countdown():
       countdown_content = f"{user.mention} Day {current}! Good luck :D" if current == self.days else f"{user.mention} Day {current}"
-      # current != self.days and await self.channel.edit(name=f"{self.user.name}-day-{current}"); # channel edit rate limit is 2 per 10 minutes
+      current != self.days and await self.channel.edit(name=f"{self.user.name}-day-{current}"); # channel edit rate limit is 2 per 10 minutes
       countdown_message = await channel.send(countdown_content);
 
       CountdownDatabase().update_countdown_message(countdown_message.id, self.countdown_uuid);

--- a/timer/timer.py
+++ b/timer/timer.py
@@ -53,12 +53,13 @@ class Timer():
       # Deletes existing countdown message
       # This is so we can properly ping the user in a new message when the day timer gets called again
       countdown = CountdownDatabase().get_countdown(uuid=self.countdown_uuid);
-      message = self.channel.get_partial_message(countdown["message_id"]);
-      await message.delete();
+      if countdown:
+        message = self.channel.get_partial_message(countdown["message_id"]);
+        await message.delete();
 
-      await asyncio.sleep(3); # Buffer time; perhaps there's a better way of going about this
-      self.update_next_timer(); # Updates timer pointers for the next day
-      return await self.start(); # Calls itself
+        await asyncio.sleep(3); # Buffer time; perhaps there's a better way of going about this
+        self.update_next_timer(); # Updates timer pointers for the next day
+        return await self.start(); # Calls itself
     else:
       # Send end of countdown message
       embed = self.generate_end_countdown_embed();

--- a/timer/timer.py
+++ b/timer/timer.py
@@ -53,6 +53,14 @@ class Timer():
       # Deletes existing countdown message
       # This is so we can properly ping the user in a new message when the day timer gets called again
       countdown = CountdownDatabase().get_countdown(uuid=self.countdown_uuid);
+
+      # Wrapping the next timer calls in a countdown existence conditional
+      # I'll admit this is a ghetto alternative
+      # The proper way is to clear the existing asyncio tasks when we stop a countdown
+      # However, I'm not too versed with the module yet
+      # As the timer task isn't cleared, it will continue and finish leading to the methods below
+      # It will run into an error when trying to get the message as countdown doesn't exist anymore
+      # Hence to prevent that, this condition is made. Told you it was ghetto, maybe I'll refactor in the future
       if countdown:
         message = self.channel.get_partial_message(countdown["message_id"]);
         await message.delete();

--- a/timer/timer.py
+++ b/timer/timer.py
@@ -58,13 +58,14 @@ class Timer():
 
       await asyncio.sleep(3); # Buffer time; perhaps there's a better way of going about this
       self.update_next_timer(); # Updates timer pointers for the next day
-      await self.start(); # Calls itself
+      return await self.start(); # Calls itself
     else:
       # Send end of countdown message
       embed = self.generate_end_countdown_embed();
       view = self.generate_button();
       # await self.channel.edit(name=f"{self.user.name}-end"); # channel edit rate limit is 2 per 10 minutes
-      await self.channel.send(f'{self.user.mention}', embed=embed, view=view);
+      end_message = await self.channel.send(f'{self.user.mention}', embed=embed, view=view);
+      return CountdownDatabase().update_countdown_message(end_message.id, self.countdown_uuid);
     
   # Updates timer pointers for next day
   # Important to keep the timer flowing
@@ -97,7 +98,7 @@ class Timer():
 
       return await asyncio.sleep(difference);
 
-    await start_countdown()
+    return await start_countdown()
 
   # Generates embed for the end countdown message
   def generate_end_countdown_embed(self):


### PR DESCRIPTION
#### Context
HONESTLY NO IDEA WHAT IM DOING. Need to read up on asyncio more, my knowledge on it is laughable but somehow magically found my way into a working solution. At least now even if the bot restarts, it can continue with the correct timer as well as delete existing countdowns and their channels. The only ghetto part is I don't clear asyncio tasks when I stop countdowns and it silently finishes in the background

And with this we're done, what a journey creating this

#### Change
- Run existing countdowns on start up
- Delete ended countdowns on start up
- Update countdown message id for end message
- Wrap callback in a countdown existence conditional
- Remove minute type

#### Release Notes
Countdown interactions on start up