### PR TITLE
Remove guild ids from slash commands

### DIFF
--- a/cogs/about.py
+++ b/cogs/about.py
@@ -32,7 +32,7 @@ class About(commands.Cog):
     return embed;
 
   # Register slash command and main handler for initialisation
-  @slash_command(guild_ids=config["guildIDs"], description="Displays information about Mirai")
+  @slash_command(description="Displays information about Mirai")
   async def about(self, ctx):
     embed = self.generate_about_embed(ctx);
     return await ctx.respond(embed=embed);

--- a/cogs/countdown.py
+++ b/cogs/countdown.py
@@ -108,7 +108,7 @@ class Countdown(commands.Cog):
     return await Timer(countdown_channel, user, countdown).start();
 
   # Register slash command and main handler for initialisation
-  @slash_command(guild_ids=config["guildIDs"], description="Starts a countdown from a set number of days")
+  @slash_command(description="Starts a countdown from a set number of days")
   async def countdown(self, ctx, days: Option(int, "Enter number of days!", required=False), stop: Option(discord.TextChannel, "Stops an existing countdown", required=False)):
     # If no options are passed, we show the command information
     if not days and not stop:


### PR DESCRIPTION
#### Context
Remove guild ids from slash commands to be able to register them as global. Honestly not too sure how this is going to work out, with guild ids it updates the commands instantly but apparently global takes up to an hour. Also can it be passed as None? an empty list? or does it have to be explicitly not passed as an argument. Going to be safe for now and not pass anything

#### Change
- Remove guild ids

#### Release Notes
Remove guild ids from slash commands