### PR TITLE
Add error handling and logging

### DIFF
--- a/cogs/about.py
+++ b/cogs/about.py
@@ -37,10 +37,10 @@ class About(commands.Cog):
     try:
       embed = self.generate_about_embed();
       return await ctx.respond(embed=embed);
-    except Exception as e:
+    except Exception as error:
       error_embed = Helpers().generate_error_embed("Oops something went wrong! D: Try again in a bit!");
       await ctx.respond(embed=error_embed);
-      return await Helpers().send_error_log(self.bot, e);
+      return await Helpers().send_error_log(self.bot, ctx, error, "About Command");
 
 
 def setup(bot: commands.Bot):

--- a/cogs/about.py
+++ b/cogs/about.py
@@ -38,8 +38,9 @@ class About(commands.Cog):
       embed = self.generate_about_embed();
       return await ctx.respond(embed=embed);
     except Exception as e:
-        await ctx.respond('Oops something went wrong! D: Try again in a bit!')
-        return await Helpers().send_error_log(self.bot, e);
+      error_embed = Helpers().generate_error_embed("Oops something went wrong! D: Try again in a bit!");
+      await ctx.respond(embed=error_embed);
+      return await Helpers().send_error_log(self.bot, e);
 
 
 def setup(bot: commands.Bot):

--- a/cogs/about.py
+++ b/cogs/about.py
@@ -34,9 +34,13 @@ class About(commands.Cog):
   # Register slash command and main handler for initialisation
   @slash_command(description="Displays information about Mirai")
   async def about(self, ctx):
-    embed = self.generate_about_embed();
-    return await ctx.respond(embed=embed);
-  
+    try:
+      embed = self.generate_about_embed();
+      return await ctx.respond(embed=embed);
+    except Exception as e:
+        await ctx.respond('Oops something went wrong! D: Try again in a bit!')
+        return await Helpers().send_error_log(self.bot, e);
+
 
 def setup(bot: commands.Bot):
   bot.add_cog(About(bot));

--- a/cogs/countdown.py
+++ b/cogs/countdown.py
@@ -61,10 +61,10 @@ class Countdown(commands.Cog):
       embed.description = "Cancelled Countdown";
 
       return await interaction.response.edit_message(embed=embed, view=None);
-    except Exception as e:
+    except Exception as error:
       error_embed = Helpers().generate_error_embed("Oops something went wrong! D: Try again in a bit!");
       await interaction.response.edit_message(embed=error_embed, view=None);
-      return await Helpers().send_error_log(self.bot, e);
+      return await Helpers().send_error_log(self.bot, interaction, error, "Cancel Countdown");
 
   # Handler when a user clicks the Let's go Button
   # 4 parts:
@@ -99,10 +99,10 @@ class Countdown(commands.Cog):
 
       # Calls the start_countdown function to start timer
       return await self.start_countdown(interaction.user.id, interaction.guild.id);
-    except Exception as e:
+    except Exception as error:
       error_embed = Helpers().generate_error_embed("Oops something went wrong! D: Try again in a bit!");
       await interaction.response.edit_message(embed=error_embed, view=None);
-      return await Helpers().send_error_log(self.bot, e);
+      return await Helpers().send_error_log(self.bot, interaction, error, "Confirm Countdown");
 
   # Starts countdown timer
   # Retrieves countdown instance from our database 
@@ -115,7 +115,7 @@ class Countdown(commands.Cog):
     countdown_channel = self.bot.get_channel(countdown["channel_id"]);
     user = await self.bot.fetch_user(countdown["user_id"]);
 
-    return await Timer(self.bot, countdown_channel, user, countdown).start();
+    return await Timer(self.bot, countdown_channel, user, countdown, 'minute').start();
 
   # Register slash command and main handler for initialisation
   @slash_command(description="Starts a countdown from a set number of days")
@@ -167,10 +167,10 @@ class Countdown(commands.Cog):
       embed = self.generate_countdown_confirmation_embed(days);
 
       return await ctx.respond(embed=embed, view=actions_view);
-    except Exception as e:
+    except Exception as error:
       error_embed = Helpers().generate_error_embed("Oops something went wrong! D: Try again in a bit!");
       await ctx.respond(embed=error_embed);
-      return await Helpers().send_error_log(self.bot, e);
+      return await Helpers().send_error_log(self.bot, ctx, error, "Countdown Command");
 
 
 def setup(bot: commands.Bot):

--- a/cogs/countdown.py
+++ b/cogs/countdown.py
@@ -70,29 +70,34 @@ class Countdown(commands.Cog):
   # I initially wanted to move the user to the text channel but seems discord doesn't support that; only voice channel movement. 
   # I guess it's hard to keep track and merits probably doesn't outweight the implementation
   async def handle_on_confirm(self, interaction):
-    # Creates a new channel under a new category
-    current_guild = await self.bot.fetch_guild(interaction.guild_id);
-    countdown_category = await current_guild.create_category('Mirai Countdown');
-    countdown_channel = await countdown_category.create_text_channel(f'{interaction.user.name}-day-{self.days}');
+    try:
+      # Creates a new channel under a new category
+      current_guild = await self.bot.fetch_guild(interaction.guild_id);
+      countdown_category = await current_guild.create_category('Mirai Countdown');
+      countdown_channel = await countdown_category.create_text_channel(f'{interaction.user.name}-day-{self.days}');
 
-    # Creates a countdown instance in our database
-    # More information in countdown_db
-    CountdownDatabase({
-      "user": interaction.user,
-      "guild": current_guild,
-      "category_channel": countdown_category,
-      "channel": countdown_channel,
-      "days": self.days      
-    }).create_countdown();
+      # Creates a countdown instance in our database
+      # More information in countdown_db
+      CountdownDatabase({
+        "user": interaction.user,
+        "guild": current_guild,
+        "category_channel": countdown_category,
+        "channel": countdown_channel,
+        "days": self.days      
+      }).create_countdown();
 
-    # Edits original interaction message with link to new channel
-    embed = discord.Embed();
-    embed.color = discord.Colour(3066993);
-    embed.description = f"Countdown successfully set in {countdown_channel.mention}!";
-    await interaction.response.edit_message(embed=embed, view=None);
+      # Edits original interaction message with link to new channel
+      embed = discord.Embed();
+      embed.color = discord.Colour(3066993);
+      embed.description = f"Countdown successfully set in {countdown_channel.mention}!";
+      await interaction.response.edit_message(embed=embed, view=None);
 
-    # Calls the start_countdown function to start timer
-    return await self.start_countdown(interaction.user.id, interaction.guild.id);
+      # Calls the start_countdown function to start timer
+      return await self.start_countdown(interaction.user.id, interaction.guild.id);
+    except Exception as e:
+      error_embed = Helpers().generate_error_embed("Oops something went wrong! D: Try again in a bit!");
+      await interaction.response.edit_message(embed=error_embed, view=None);
+      return await Helpers().send_error_log(self.bot, e);
 
   # Starts countdown timer
   # Retrieves countdown instance from our database 
@@ -158,7 +163,8 @@ class Countdown(commands.Cog):
 
       return await ctx.respond(embed=embed, view=actions_view);
     except Exception as e:
-      await ctx.respond('Oops something went wrong! D: Try again in a bit!')
+      error_embed = Helpers().generate_error_embed("Oops something went wrong! D: Try again in a bit!");
+      await ctx.respond(embed=error_embed);
       return await Helpers().send_error_log(self.bot, e);
 
 

--- a/cogs/countdown.py
+++ b/cogs/countdown.py
@@ -55,11 +55,16 @@ class Countdown(commands.Cog):
   # Handler when a user clicks the Cancel Button
   # Edits the original message with a new embed and clears buttons
   async def handle_on_cancel(self, interaction):
-    embed = discord.Embed();
-    embed.color = discord.Colour(16711680);
-    embed.description = "Cancelled Countdown";
+    try:
+      embed = discord.Embed();
+      embed.color = discord.Colour(16711680);
+      embed.description = "Cancelled Countdown";
 
-    return await interaction.response.edit_message(embed=embed, view=None);
+      return await interaction.response.edit_message(embed=embed, view=None);
+    except Exception as e:
+      error_embed = Helpers().generate_error_embed("Oops something went wrong! D: Try again in a bit!");
+      await interaction.response.edit_message(embed=error_embed, view=None);
+      return await Helpers().send_error_log(self.bot, e);
 
   # Handler when a user clicks the Let's go Button
   # 4 parts:
@@ -110,7 +115,7 @@ class Countdown(commands.Cog):
     countdown_channel = self.bot.get_channel(countdown["channel_id"]);
     user = await self.bot.fetch_user(countdown["user_id"]);
 
-    return await Timer(countdown_channel, user, countdown).start();
+    return await Timer(self.bot, countdown_channel, user, countdown).start();
 
   # Register slash command and main handler for initialisation
   @slash_command(description="Starts a countdown from a set number of days")

--- a/cogs/countdown.py
+++ b/cogs/countdown.py
@@ -115,7 +115,7 @@ class Countdown(commands.Cog):
     countdown_channel = self.bot.get_channel(countdown["channel_id"]);
     user = await self.bot.fetch_user(countdown["user_id"]);
 
-    return await Timer(self.bot, countdown_channel, user, countdown, 'minute').start();
+    return await Timer(self.bot, countdown_channel, user, countdown).start();
 
   # Register slash command and main handler for initialisation
   @slash_command(description="Starts a countdown from a set number of days")

--- a/helpers.py
+++ b/helpers.py
@@ -24,3 +24,10 @@ class Helpers():
   async def send_error_log(self, bot, error):
     dev_channel = bot.get_channel(933016043310440519);
     return await dev_channel.send(str(error));
+
+  def generate_error_embed(self, message):
+    embed = discord.Embed();
+    embed.color = discord.Colour(16711680);
+    embed.description = message;
+    
+    return embed;

--- a/helpers.py
+++ b/helpers.py
@@ -21,13 +21,25 @@ class Helpers():
   def format_to_datetime(self, date_string):
     return datetime.datetime.strptime(date_string, '%Y-%m-%d %H:%M:%S.%f');
 
-  async def send_error_log(self, bot, error):
-    dev_channel = bot.get_channel(933016043310440519);
-    return await dev_channel.send(str(error));
-
   def generate_error_embed(self, message):
     embed = discord.Embed();
     embed.color = discord.Colour(16711680);
     embed.description = message;
     
     return embed;
+
+  async def send_error_log(self, bot, ctx, error, type):
+    embed = discord.Embed();
+    embed.color = discord.Colour(16711680);
+    embed.title = f"Error | {type}";
+    embed.description = f"uuid: {self.generate_uuid()}\nError: {str(error)}";
+    
+    embed.add_field(name="User", value=ctx.user.name, inline=True);
+    embed.add_field(name="User ID", value=ctx.user.id, inline=True);
+    embed.add_field(name="Channel", value=ctx.channel.name, inline=True);
+    embed.add_field(name="Channel ID", value=ctx.channel.id, inline=True);
+    embed.add_field(name="Guild", value=ctx.guild.name, inline=True);
+    embed.add_field(name="Guild ID", value=ctx.guild.id, inline=True);
+    
+    dev_channel = bot.get_channel(933016043310440519);
+    return await dev_channel.send(embed=embed);

--- a/helpers.py
+++ b/helpers.py
@@ -20,3 +20,7 @@ class Helpers():
 
   def format_to_datetime(self, date_string):
     return datetime.datetime.strptime(date_string, '%Y-%m-%d %H:%M:%S.%f');
+
+  async def send_error_log(self, bot, error):
+    dev_channel = bot.get_channel(933016043310440519);
+    return await dev_channel.send(str(error));

--- a/mirai.py
+++ b/mirai.py
@@ -35,7 +35,7 @@ async def run_existing_countdowns():
       countdown_message = countdown_channel.get_partial_message(countdown["message_id"]);
       user = await mirai.fetch_user(countdown["user_id"]);
       countdown_message and await countdown_message.delete();
-      countdown_tasks.append(asyncio.create_task(Timer(countdown_channel, user, countdown).start()));
+      countdown_tasks.append(asyncio.create_task(Timer(mirai, countdown_channel, user, countdown).start()));
     else:
       await countdown_channel.category.delete();
       await countdown_channel.delete();

--- a/timer/timer.py
+++ b/timer/timer.py
@@ -131,6 +131,11 @@ class Timer():
   # Deletes countdown instance from our database
   # Then deletes the countdown category and channel
   async def handle_on_close(self, interaction):
-    CountdownDatabase().delete_countdown(self.countdown_uuid);
-    await interaction.channel.category.delete();
-    return await interaction.channel.delete();
+    try:
+      CountdownDatabase().delete_countdown(self.countdown_uuid);
+      await interaction.channel.category.delete();
+      return await interaction.channel.delete();
+    except Exception as e:
+      error_embed = Helpers().generate_error_embed("Oops something went wrong! D:\n\n I've notified the owner about the problem, feel free to delete this channel!");
+      await interaction.response.edit_message(embed=error_embed, view=None);
+      return await Helpers().send_error_log(self.bot, e);

--- a/timer/timer.py
+++ b/timer/timer.py
@@ -135,7 +135,7 @@ class Timer():
       CountdownDatabase().delete_countdown(self.countdown_uuid);
       await interaction.channel.category.delete();
       return await interaction.channel.delete();
-    except Exception as e:
+    except Exception as error:
       error_embed = Helpers().generate_error_embed("Oops something went wrong! D:\n\n I've notified the owner about the problem, feel free to delete this channel!");
       await interaction.response.edit_message(embed=error_embed, view=None);
-      return await Helpers().send_error_log(self.bot, e);
+      return await Helpers().send_error_log(self.bot, interaction, error, "End Close Countdown");

--- a/timer/timer.py
+++ b/timer/timer.py
@@ -20,7 +20,8 @@ class Timer():
   # user: discord User - for pinging purposes
   # countdown: countdown instance from our database
   # type: if timer should use days or minutes; latter more on testing but could be an additional feature in the future
-  def __init__(self, channel, user, countdown, type="day"):
+  def __init__(self, bot, channel, user, countdown, type="day"):
+    self.bot = bot;
     self.date_now = datetime.datetime.now();
     self.started_at = Helpers().format_to_datetime(countdown["started_at"]);
     self.ends_at = Helpers().format_to_datetime(countdown["ends_at"]);


### PR DESCRIPTION
#### Context
Add some sort of error handing and logging. Had an issue with closing a countdown when it was finished; button kept failing and have no idea what was happening. What's even weirder is the countdown got deleted along with its channels after a restart, weird since it uses the same code. Anyway cooked up some simple error messages and send error details to a log channel in mirai's discord
![image](https://user-images.githubusercontent.com/42207245/149981724-8d01a37f-0fd1-4ea4-af6d-2b96843cf662.png)
![image](https://user-images.githubusercontent.com/42207245/149981806-fe398986-0627-402e-a05c-73872881a23f.png)

#### Change
- Add error handling on commands
- Add error handling on interactions
- Send error details to log channel

#### Considerations
Only added handling on a command and interaction level. Didn't want to add on the actual timer as that might get too complicated along with discord errors. Will look into it when I get the time, I want to move to another project for now

#### Release Notes
Add error handing and logging