### PR TITLE
Add no timeout to countdown end message

### DIFF
--- a/cogs/countdown.py
+++ b/cogs/countdown.py
@@ -46,7 +46,7 @@ class Countdown(commands.Cog):
     view = View();
     view.add_item(cancel_button);
     view.add_item(confirm_button);
-
+    
     confirm_button.callback = self.handle_on_confirm;
     cancel_button.callback = self.handle_on_cancel;
     

--- a/timer/timer.py
+++ b/timer/timer.py
@@ -121,7 +121,7 @@ class Timer():
   # Generates close button for end countdown message
   def generate_button(self):
     close_button = Button(label="Close", style=discord.ButtonStyle.secondary);
-    view = View();
+    view = View(timeout=None); # Default is 3 minutes; setting to none as we want users to close the channel whenever they want
     view.add_item(close_button);
     close_button.callback = self.handle_on_close;
     


### PR DESCRIPTION
#### Context
Add no timeout to countdown end button. This one frustrated me so much. I thought the problem was the interaction token becoming invalidated as that's the most probable issue. However it was actually way simpler. Apparently pycord puts a default 3 minute timeout on its views so it would stop interacting with user input. Pycord's api documentation is one hell of a mess holyy lost my mind for a good hour. Oh well, at least this is now fixed and learnt new stuff

#### Change
- Add no timeout to countdown end button

#### Release Notes
Add no timeout to countdown end button