### PR TITLE
Release/2022 01 24

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+# v1.1.1 (Mon Jan 24 2022)
+
+### Release Notes
+
+#### Add no timeout to countdown end message ([#18](https://github.com/vexuas/mirai/pull/18))
+
+Add no timeout to countdown end button
+
+---
+
+#### 🐛 Bug Fix
+
+- Add no timeout to countdown end message [#18](https://github.com/vexuas/mirai/pull/18) ([@vexuas](https://github.com/vexuas))
+
+#### 🏠 Internal
+
+- Release/2022 01 19 [#17](https://github.com/vexuas/mirai/pull/17) ([@vexuas](https://github.com/vexuas))
+
+#### Authors: 1
+
+- Gabriel R ([@vexuas](https://github.com/vexuas))
+
+---
+
 # v1.1.0 (Wed Jan 19 2022)
 
 ### Release Notes

--- a/cogs/about.py
+++ b/cogs/about.py
@@ -26,7 +26,7 @@ class About(commands.Cog):
     embed.add_field(name="Date Created", value=self.bot.user.created_at.strftime('%d-%b-%Y'), inline=True);
     embed.add_field(name="Version", value=package["version"], inline=True);
     embed.add_field(name="Library", value="Pycord", inline=True);
-    embed.add_field(name="Last Update", value="19-Jan-2022", inline=True);
+    embed.add_field(name="Last Update", value="24-Jan-2022", inline=True);
     embed.add_field(name="Source Code", value="[Github](https://github.com/vexuas/mirai)", inline=True);
 
     return embed;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mirai",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Countdown Discord Bot",
   "devDependencies": {
     "auto": "^10.32.5"


### PR DESCRIPTION
# v1.1.1 (Mon Jan 24 2022)
#### 🐛 Bug Fix

- Add no timeout to countdown end message [#18](https://github.com/vexuas/mirai/pull/18) ([@vexuas](https://github.com/vexuas))

#### 🏠 Internal

- Release/2022 01 19 [#17](https://github.com/vexuas/mirai/pull/17) ([@vexuas](https://github.com/vexuas))

#### Authors: 1

- Gabriel R ([@vexuas](https://github.com/vexuas))

---